### PR TITLE
Handle redirects when checking ECT Provider

### DIFF
--- a/os-scan/get_SAPInformations.py
+++ b/os-scan/get_SAPInformations.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -8,8 +9,19 @@ def get_SapInformations(environment,header):
 
     url = environment+'/SAPDevService/rest/SAP/CheckSAPHealth'
 
-    # Sending a GET request to the URL
-    response = requests.get(url, headers=header, verify=False)
+    # Sending a GET request to the URL without automatically following redirects
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}SAP Check aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -24,8 +36,20 @@ def get_SapInformations(environment,header):
         print(f"| {Fore.WHITE}SAP Connector Version: {Style.DIM}[{sap_conect_version}]{Style.RESET_ALL}")
         print(f"| {Fore.WHITE}Exposed API documentation: {Style.DIM}[{environment}/SAPDevService/rest/SAP/]{Style.RESET_ALL}")
     else:
-        # The request failed
-        # Printing the response code and error message
-        # Print the key normally
-        print(f"{Fore.RED}There was a problem trying to access the url, more details below:{Style.RESET_ALL}")
-        print(f"{Fore.RED}{Style.DIM}get_SAPInformations.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}The SAP health endpoint redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            # Printing the response code and error message
+            print(
+                f"{Fore.RED}There was a problem trying to access the url, more details below:{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}{Style.DIM}get_SAPInformations.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}"
+            )


### PR DESCRIPTION
## Summary
- avoid following redirects when checking the ECT Provider
- show the redirect destination for the ECT Provider check
- ensure newline at end of SAP health check file

## Testing
- `python3 -m py_compile os-scan/get_AppFeedback.py`
- `python3 -m py_compile os-scan/get_SAPInformations.py`
- `python3 -m py_compile os-scan/*.py os-scan/exploits/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684c6791518c8331ac329176af44f08f