### PR TITLE
Handle redirects when checking all modules

### DIFF
--- a/os-scan/exploits/check_CKEditor.py
+++ b/os-scan/exploits/check_CKEditor.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import json
 import re
 import urllib3
@@ -44,9 +45,20 @@ def exploit_api_file_storage(environment,component_name):
         print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] Failed to upload the file or the upload attribute is not vulnerable.{Style.RESET_ALL}")
 
 def exploit_CVE202224728(environment,header,component_name):
-    # Sending a GET request to the URL
+    # Sending a GET request to the URL without following redirects
     url = environment+'/CKEditorReactive/ckeditor/ckeditor.js'
-    response = requests.get(url, headers=header, verify=False)
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] Request aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -65,5 +77,19 @@ def exploit_CVE202224728(environment,header,component_name):
                 print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}")
                 print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2022-24728.{Style.RESET_ALL}")
     else:
-        print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}")
-        print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2022-24728.{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}[|||] Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] The ckeditor.js endpoint redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}"
+            )
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2022-24728.{Style.RESET_ALL}"
+            )

--- a/os-scan/exploits/check_FroalaEditor.py
+++ b/os-scan/exploits/check_FroalaEditor.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import re
 import urllib3
 
@@ -10,9 +11,20 @@ def call_FroalaEditor_exploits(environment,app_module_name,header,component_name
     exploit_CVE202341592(environment,header,component_name)
 
 def exploit_CVE202341592(environment,header,component_name):
-    # Sending a GET request to the URL
+    # Sending a GET request to the URL without following redirects
     url = environment+'/FroalaEditor_Demo/Blocks/FroalaEditor/Scripts/froala_editor.js'
-    response = requests.get(url, headers=header, verify=False)
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] Request aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -33,5 +45,19 @@ def exploit_CVE202341592(environment,header,component_name):
                 print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}")
                 print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2023-41592.{Style.RESET_ALL}")
     else:
-        print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}")
-        print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2023-41592.{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}[|||] Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] The froala_editor.js endpoint redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] XSS injected failed!{Style.RESET_ALL}"
+            )
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version of the component is not vulnerable to CVE-2023-41592.{Style.RESET_ALL}"
+            )

--- a/os-scan/exploits/check_PDFTron.py
+++ b/os-scan/exploits/check_PDFTron.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import re
 import urllib3
 
@@ -10,9 +11,20 @@ def call_PDFTron_exploits(environment,app_module_name,header,component_name):
     check_version_js(environment,header,component_name)
 
 def check_version_js(environment,header,component_name):
-    # Sending a GET request to the URL
+    # Sending a GET request to the URL without following redirects
     url = environment+'/PDFTron/scripts/PDFTron.webviewer_min.js'
-    response = requests.get(url, headers=header, verify=False)
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] Request aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -31,4 +43,16 @@ def check_version_js(environment,header,component_name):
         else:
             print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version is not vulnerable to XSS via PDF viewing.{Style.RESET_ALL}")
     else:
-        print(f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version is not vulnerable to XSS via PDF viewing.{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}[|||] Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] The PDFTron script redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            print(
+                f"| {Fore.WHITE}[|||] {Style.DIM}[{component_name}] This version is not vulnerable to XSS via PDF viewing.{Style.RESET_ALL}"
+            )

--- a/os-scan/get_ClientVariables.py
+++ b/os-scan/get_ClientVariables.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import re
 import urllib3
 
@@ -9,9 +10,20 @@ def get_all_clientvaribles(environment,app_module_name,header):
 
     potential_defaultvalue_found = False
 
-    # Sending a GET request to the URL
+    # Sending a GET request to the URL without following redirects
     url = environment+'/'+app_module_name+'/scripts/'+app_module_name+'.clientVariables.js'
-    response = requests.get(url, headers=header, verify=False)
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}ClientVariables check aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -32,8 +44,20 @@ def get_all_clientvaribles(environment,app_module_name,header):
                 else:
                     print(f"| {Fore.WHITE}[200] {Style.DIM}{item_content}{Style.RESET_ALL}")
     else:
-        # Error in request
-        print(f"{Fore.RED}{Style.DIM}get_clientvariables.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}The ClientVariables script redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            # Error in request
+            print(
+                f"{Fore.RED}{Style.DIM}get_clientvariables.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}"
+            )
     
     if potential_defaultvalue_found:
         print(f"{Fore.RED}[i] Potential default values found in one or more ClientVar listed in{Style.RESET_ALL} {Fore.YELLOW}yellow{Style.RESET_ALL} {Fore.RED}above.{Style.RESET_ALL}")

--- a/os-scan/get_MobileApp.py
+++ b/os-scan/get_MobileApp.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import json
 import urllib3
 
@@ -7,9 +8,20 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 def get_mobile_apps(environment,header):
 
-    # Sending a GET request to the URL
+    # Sending a GET request to the URL without following redirects
     url = environment+'/NativeAppBuilder/rest/NativeApps/GetNativeApps'
-    response = requests.get(url, headers=header, verify=False)
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}Mobile apps check aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -22,5 +34,17 @@ def get_mobile_apps(environment,header):
             else:
                 print(f"| {Fore.WHITE}[200] {Style.DIM}{response.text}{Style.RESET_ALL}")
     else:
-        # Error in request
-        print(f"{Fore.RED}{Style.DIM}get_mobileapp.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}The mobile apps endpoint redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            # Error in request
+            print(
+                f"{Fore.RED}{Style.DIM}get_mobileapp.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}"
+            )

--- a/os-scan/get_SAPInformations.py
+++ b/os-scan/get_SAPInformations.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 import requests
+from requests.exceptions import TooManyRedirects
 import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -8,8 +9,19 @@ def get_SapInformations(environment,header):
 
     url = environment+'/SAPDevService/rest/SAP/CheckSAPHealth'
 
-    # Sending a GET request to the URL
-    response = requests.get(url, headers=header, verify=False)
+    # Sending a GET request to the URL without automatically following redirects
+    try:
+        response = requests.get(
+            url,
+            headers=header,
+            verify=False,
+            allow_redirects=False,
+        )
+    except TooManyRedirects:
+        print(
+            f"| {Fore.WHITE}SAP Check aborted due to too many redirects.{Style.RESET_ALL}"
+        )
+        return
 
     # Checking the response code
     if response.status_code == 200:
@@ -24,8 +36,20 @@ def get_SapInformations(environment,header):
         print(f"| {Fore.WHITE}SAP Connector Version: {Style.DIM}[{sap_conect_version}]{Style.RESET_ALL}")
         print(f"| {Fore.WHITE}Exposed API documentation: {Style.DIM}[{environment}/SAPDevService/rest/SAP/]{Style.RESET_ALL}")
     else:
-        # The request failed
-        # Printing the response code and error message
-        # Print the key normally
-        print(f"{Fore.RED}There was a problem trying to access the url, more details below:{Style.RESET_ALL}")
-        print(f"{Fore.RED}{Style.DIM}get_SAPInformations.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}")
+        # The request failed or was redirected
+        if response.status_code in (301, 302, 303, 307, 308):
+            redirect_to = response.headers.get("Location", "unknown")
+            print(
+                f"| {Fore.WHITE}Request redirected to: {Style.DIM}[{redirect_to}]{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}The SAP health endpoint redirected instead of returning data.{Style.RESET_ALL}"
+            )
+        else:
+            # Printing the response code and error message
+            print(
+                f"{Fore.RED}There was a problem trying to access the url, more details below:{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.RED}{Style.DIM}get_SAPInformations.py - Erro: {response.status_code} - {response.reason}{Style.RESET_ALL}"
+            )


### PR DESCRIPTION
## Summary
- handle redirect loops for modules and exploits
- surface redirect destinations in osscan

## Testing
- `python3 -m py_compile os-scan/get_Roles.py os-scan/get_ClientVariables.py os-scan/get_AppDefinitions.py os-scan/get_ModulesReferences.py os-scan/get_MobileApp.py os-scan/exploits/check_CKEditor.py os-scan/exploits/check_FroalaEditor.py os-scan/exploits/check_PDFTron.py os-scan/osscan.py os-scan/get_AppFeedback.py os-scan/get_SAPInformations.py`
- `python3 -m py_compile os-scan/*.py os-scan/exploits/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684c6791518c8331ac329176af44f08f